### PR TITLE
v.0.0.4 sync period current_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.4
+  * Change `sync.py` for `periodic_data_calculated` to use `current_date` and not `latest_date` for `ReportedDate`, based on vendor recommendation.
+
 ## 0.0.3
   * Re-work `periodic_data_standardized`, bookmarks. Add `periodic_data_calculated`.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-ilevel',
-      version='0.0.3',
+      version='0.0.4',
       description='Singer.io tap for extracting data from the ilevel 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_ilevel/sync.py
+++ b/tap_ilevel/sync.py
@@ -406,7 +406,7 @@ def __process_periodic_data_calcs(req_state, scenario_name='Actual', currency_co
     data_item_search_criteria = req_state.client.factory.create('DataItemsSearchCriteria')
     data_item_search_criteria.GetGlobalDataItemsOnly = True # Global Data Items ONLY
     data_items = req_state.client.service.GetDataItems(data_item_search_criteria)
-    calc_data_items = [i for i in data_items.DataItemObjectEx if i.FormulaTypeIDsString] # TESTING (add): and 'Revenue' in i.Name
+    calc_data_items = [i for i in data_items.DataItemObjectEx if i.FormulaTypeIDsString] # TESTING (add): and 'Gross Margin' in i.Name
     calc_data_items_len = len(calc_data_items)
     last_calc_data_item = calc_data_items[-1]
     
@@ -421,7 +421,7 @@ def __process_periodic_data_calcs(req_state, scenario_name='Actual', currency_co
         else: # assets
             entities = req_state.client.service.GetAssets()
             entity_objs = entities.Asset
-            # entity_objs = [i for i in entity_objs if 'Cleo' in i.Name] # TESTING: COMMENT OUT
+            # entity_objs = [i for i in entity_objs if 'Guild Education' in i.Name] # TESTING: COMMENT OUT
         entity_objs_len = len(entity_objs)
     
         # calc_data_items loop
@@ -473,7 +473,7 @@ def __process_periodic_data_calcs(req_state, scenario_name='Actual', currency_co
                         i_get_params.Period = period
                         i_get_params.Offset = offset_period
                         i_get_params.EndOfPeriod = latest_date
-                        i_get_params.ReportedDate = latest_date
+                        i_get_params.ReportedDate = current_date
                         i_get_params.CurrencyCode = currency_code
 
                         i_get_params_list.BaseRequestParameters.append(i_get_params)
@@ -500,7 +500,7 @@ def __process_periodic_data_calcs(req_state, scenario_name='Actual', currency_co
                             with metrics.http_request_timer(metrics_string) as timer:
                                 data_values = req_state.client.service.iGetBatch(i_get_request)
 
-                            # LOGGER.info('data_values dict = {}'.format(sobject_to_dict(data_values))) # COMMENT OUT
+                            # LOGGER.info('data_values = {}'.format(data_values)) # COMMENT OUT
 
                             if isinstance(data_values, str):
                                 continue


### PR DESCRIPTION
# Description of change
Change `sync.py` for `periodic_data_calculated` to use `current_date` and not `latest_date` for `ReportedDate`, based on vendor recommendation.

# Manual QA steps
Fixed issue. Ran singer-discover, singer-check-tap, target-stitch (initial load and incremental) for primary endpoints. Reviewed data for affected endpoint `periodic_data_calculated`. Verified previously missing records were loaded.

# Risks
Low. Currently in Alpha or Beta with Bytecode and Felicis.
 
# Rollback steps
Revert to v.0.0.3.
