### PR TITLE
v.1.0.0 hash_key and lookback changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.0
+  * Major version change of primary `hash_key` fields for `periodic_data_calculated` and `periodic_data_standardized`. Added lookback window and data window overlap due to some changes not replicating.
+
 ## 0.0.4
   * Change `sync.py` for `periodic_data_calculated` to use `current_date` and not `latest_date` for `ReportedDate`, based on vendor recommendation.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-ilevel',
-      version='0.0.4',
+      version='1.0.0',
       description='Singer.io tap for extracting data from the ilevel 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_ilevel/sync.py
+++ b/tap_ilevel/sync.py
@@ -6,7 +6,7 @@ import copy
 
 import singer
 from singer import metrics, metadata, Transformer, utils
-from singer.utils import strptime_to_utc
+from singer.utils import strftime, strptime_to_utc
 
 from tap_ilevel.transform import transform_json, hash_data
 from tap_ilevel.streams import STREAMS
@@ -89,7 +89,8 @@ def process_records(result_records,
                 else:
                     max_bookmark_value = bookmark_dt
 
-                last_dttm = datetime.strptime(last_date, "%Y-%m-%d")
+                # Lookback window, always process last 14 days
+                last_dttm = datetime.strptime(last_date, "%Y-%m-%d") - timedelta(days=14)
 
                 # Keep only records whose bookmark is on after the last_date
                 if bookmark_dttm >= last_dttm:
@@ -552,7 +553,12 @@ def __process_periodic_data_calcs(req_state, scenario_name='Actual', currency_co
                                     dimensions = {
                                         'data_item_id': data_item_id,
                                         'entity_id': entity_id,
-                                        'excel_formula': excel_formula
+                                        'scenario_id': scenario_id,
+                                        'period_type': period_type,
+                                        'end_of_period_value': end_of_period_value,
+                                        'currency_code': currency_code,
+                                        'exchange_rate_type': exchange_rate_type,
+                                        'data_value_type': data_value_type
                                     }
                                     hash_key = str(hash_data(json.dumps(dimensions, sort_keys=True)))
 


### PR DESCRIPTION
# Description of change
Major version change of primary `hash_key` fields for `periodic_data_calculated` and `periodic_data_standardized`. Added lookback window and data window overlap due to some changes not replicating.

# Manual QA steps
Ran singer-discover, singer-check-tap, and target-stitch for all endpoints and 1 year of data. No issues.
 
# Risks
Currently in Alpha w/ Bytecode and Felicis, Stitch org ids 110918 and 156601. This is a major release and will require us drop/re-load history for 2 tables because PK `hash_key` values will change. Current PK included a field with the data item and asset names (not the keys).
 
# Rollback steps
Revert to v.0.0.4
