### PR TITLE
v.1.0.1 sync.py bookmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Adjust `sync.py` to adjust when/how we bookmark endpoint `periodic_data_standardized`. Currently, we are bookmarking too early and filtering out some records.
+  
 ## 1.0.0
   * Major version change of primary `hash_key` fields for `periodic_data_calculated` and `periodic_data_standardized`. Added lookback window and data window overlap due to some changes not replicating.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-ilevel',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the ilevel 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_ilevel/sync.py
+++ b/tap_ilevel/sync.py
@@ -283,7 +283,7 @@ def __process_incremental_stream(req_state):
 # Given a set of 'stanardized ids', reflecting attributes that have been updated for a given
 #  time window, perform any additional API requests (iGetBatch) to retrieve associated data,
 #  and publish results.
-def process_iget_batch_for_standardized_id_set(std_id_set, req_state, max_bookmark_value):
+def process_iget_batch_for_standardized_id_set(std_id_set, req_state, max_bookmark_value=None):
     update_count = 0
 
     #Retrieve additional details for id criteria.
@@ -348,8 +348,12 @@ def __process_standardized_data_stream(req_state):
         batch = 1
         for id_set in updated_object_id_sets:
             processed_record_count = 0
-            max_bookmark_value, processed_record_count = process_iget_batch_for_standardized_id_set(
-                id_set, req_state, max_bookmark_value)
+            temp_max_bookmark_value, processed_record_count = process_iget_batch_for_standardized_id_set(
+                id_set, req_state)
+            temp_max_bookmark_value_dttm = datetime.strptime(temp_max_bookmark_value, "%Y-%m-%d")
+            max_bookmark_value_dttm = datetime.strptime(max_bookmark_value, "%Y-%m-%d")
+            if temp_max_bookmark_value_dttm > max_bookmark_value_dttm:
+                max_bookmark_value = temp_max_bookmark_value
 
             LOGGER.info('periodic_data_standardized, {} - {}, Batch #{}, Requests: {}, Results: {}'.format(
                 cur_start_date, cur_end_date, batch, len(id_set), processed_record_count))


### PR DESCRIPTION
# Description of change
Minor change. Adjust `sync.py` to adjust when/how we bookmark endpoint `periodic_data_standardized`. Currently, we are bookmarking on un-sorted batches of records and this was inadvertently filtering out some records.

# Manual QA steps
Ran singer-discover, singer-check-tap, and target-stitch (initial load and incremental daily sync for a few days).
 
# Risks
Low - minor change to sync.py. Tap currently in Alpha for Bytecode and Felicis.
 
# Rollback steps
Revert to 1.0.0
