### PR TITLE
Fix when no ObjectRelationships exist in ilevel_api.py

### DIFF
--- a/tap_ilevel/ilevel_api.py
+++ b/tap_ilevel/ilevel_api.py
@@ -175,18 +175,27 @@ def get_all_objects(stream_name, client):
             data_key = 'Investment'
         elif stream_name == 'asset_to_asset_relations':
             relationships = client.service.GetObjectRelationships()
-            call_response = (relation for relation in relationships.ObjectRelationship if \
-                relation.TypeId == objectType.AssetToAsset)
+            if relationships:
+                call_response = (relation for relation in relationships.ObjectRelationship if \
+                    relation.TypeId == objectType.AssetToAsset)
+            else:
+                call_response = []
             data_key = 'ObjectRelationship'
         elif stream_name == 'fund_to_asset_relations':
             relationships = client.service.GetObjectRelationships()
-            call_response = (relation for relation in relationships.ObjectRelationship if \
-                relation.TypeId == objectType.FundToAsset)
+            if relationships:
+                call_response = (relation for relation in relationships.ObjectRelationship if \
+                    relation.TypeId == objectType.FundToAsset)
+            else:
+                call_response = []
             data_key = 'ObjectRelationship'
         elif stream_name == 'fund_to_fund_relations':
             relationships = client.service.GetObjectRelationships()
-            call_response = (relation for relation in relationships.ObjectRelationship if \
-                relation.TypeId == objectType.FundToFund)
+            if relationships:
+                call_response = (relation for relation in relationships.ObjectRelationship if \
+                    relation.TypeId == objectType.FundToFund)
+            else:
+                call_response = []
             data_key = 'ObjectRelationship'
         elif stream_name == 'data_items':
             searchCriteria = client.factory.create('DataItemsSearchCriteria')


### PR DESCRIPTION
Handle exception when there are no relationships by returning an empty list.

# Description of change
Return an empty list for ObjectRelationships instead on an exception or None.

# Manual QA steps
Pull data where there are no asset to asset relationships.
 
# Risks
None known
 
# Rollback steps
 - revert this branch
